### PR TITLE
Added withAWSV4Signature boolean from additional properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -55,6 +55,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String DATE_LIBRARY = "dateLibrary";
     public static final String JAVA8_MODE = "java8";
     public static final String SUPPORT_ASYNC = "supportAsync";
+    public static final String WITH_AWSV4_SIGNATURE = "withAWSV4Signature";
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
@@ -65,6 +66,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
     protected boolean java8Mode = true;
+    protected boolean withAWSV4Signature = false;
     protected boolean withXml = false;
     protected String invokerPackage = "org.openapitools";
     protected String groupId = "org.openapitools";
@@ -196,6 +198,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(CliOption.newBoolean(FULL_JAVA_UTIL, "whether to use fully qualified name for classes under java.util. This option only works for Java API client", fullJavaUtil));
         cliOptions.add(CliOption.newBoolean(DISCRIMINATOR_CASE_SENSITIVE, "Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client", discriminatorCaseSensitive));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, this.isHideGenerationTimestamp()));
+        cliOptions.add(CliOption.newBoolean(WITH_AWSV4_SIGNATURE, "whether to include support for SigV4 signing"));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use").defaultValue(this.getDateLibrary());
@@ -407,6 +410,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(FULL_JAVA_UTIL, fullJavaUtil);
         additionalProperties.put("javaUtilPrefix", javaUtilPrefix);
 
+        if (additionalProperties.containsKey(WITH_AWSV4_SIGNATURE)) {
+            this.setWithAWSV4Signature(Boolean.valueOf(additionalProperties.get(WITH_AWSV4_SIGNATURE).toString()));
+        }
+        additionalProperties.put(WITH_AWSV4_SIGNATURE, withAWSV4Signature);
+
         if (additionalProperties.containsKey(WITH_XML)) {
             this.setWithXml(Boolean.valueOf(additionalProperties.get(WITH_XML).toString()));
         }
@@ -498,6 +506,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             setSupportAsync(Boolean.parseBoolean(additionalProperties.get(SUPPORT_ASYNC).toString()));
             if (supportAsync) {
                 additionalProperties.put(SUPPORT_ASYNC, "true");
+            }
+        }
+
+        if (additionalProperties.containsKey(WITH_AWSV4_SIGNATURE)) {
+            setWithAWSV4Signature(Boolean.parseBoolean(additionalProperties.get(WITH_AWSV4_SIGNATURE).toString()));
+            if (withAWSV4Signature) {
+                additionalProperties.put(WITH_AWSV4_SIGNATURE, "true");
             }
         }
 
@@ -1466,6 +1481,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public void setDiscriminatorCaseSensitive(boolean discriminatorCaseSensitive) {
         this.discriminatorCaseSensitive = discriminatorCaseSensitive;
     }
+
+    public void setWithAWSV4Signature (boolean withAWSV4Signature) { this.withAWSV4Signature = withAWSV4Signature; }
 
     public void setWithXml(boolean withXml) {
         this.withXml = withXml;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This change adds a boolean called withAWSV4Signature to the AbstractJavaCodegen.java file which is set to false by default. If the user generates an SDK with the withAWSV4Signature flag set to true in the additional properties, then this boolean is set to true. This variable is used to determine the contents of the generated SDK and whether or not to include code specific to the SigV4 process when generating.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
