### PR TITLE
Added withAWSV4Signature boolean from additional properties

### DIFF
--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -42,6 +42,7 @@ sidebar_label: groovy
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/groovy|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -44,6 +44,7 @@ sidebar_label: java-inflector
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/gen/java|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -49,6 +49,7 @@ sidebar_label: java-msf4j
 |sourceFolder|source folder for generated code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java-pkmst.md
+++ b/docs/generators/java-pkmst.md
@@ -50,6 +50,7 @@ sidebar_label: java-pkmst
 |sourceFolder|source folder for generated code| |src/main/java|
 |springBootAdminUri|Spring-Boot URI| |null|
 |title|server title name or client service name| |null|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |zipkinUri|Zipkin URI| |null|
 

--- a/docs/generators/java-play-framework.md
+++ b/docs/generators/java-play-framework.md
@@ -52,6 +52,7 @@ sidebar_label: java-play-framework
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useInterfaces|Makes the controllerImp implements an interface to facilitate automatic completion when updating from version x to y of your spec| |true|
 |useSwaggerUI|Add a route to /api which show your documentation in swagger-ui. Will also import needed dependencies| |true|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 |wrapCalls|Add a wrapper to each controller function to handle things like metrics, response modification, etc..| |true|
 

--- a/docs/generators/java-undertow-server.md
+++ b/docs/generators/java-undertow-server.md
@@ -44,6 +44,7 @@ sidebar_label: java-undertow-server
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java-vertx-web.md
+++ b/docs/generators/java-vertx-web.md
@@ -44,6 +44,7 @@ sidebar_label: java-vertx-web
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -47,6 +47,7 @@ sidebar_label: java-vertx
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
 |vertxSwaggerRouterVersion|Specify the version of the swagger router library| |null|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -60,6 +60,7 @@ sidebar_label: java
 |useRxJava|Whether to use the RxJava adapter with the retrofit2 library. IMPORTANT: this option has been deprecated and will be removed in the 5.x release.| |false|
 |useRxJava2|Whether to use the RxJava2 adapter with the retrofit2 library.| |false|
 |useRxJava3|Whether to use the RxJava3 adapter with the retrofit2 library.| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -55,6 +55,7 @@ sidebar_label: jaxrs-cxf-cdi
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -48,6 +48,7 @@ sidebar_label: jaxrs-cxf-client
 |useGenericResponse|Use generic response| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|
 |useLoggingFeatureForTests|Use Logging Feature for tests| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -70,6 +70,7 @@ sidebar_label: jaxrs-cxf-extended
 |useSwaggerFeature|Use Swagger Feature| |false|
 |useSwaggerUI|Use Swagger UI| |false|
 |useWadlFeature|Use WADL Feature| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -65,6 +65,7 @@ sidebar_label: jaxrs-cxf
 |useSwaggerFeature|Use Swagger Feature| |false|
 |useSwaggerUI|Use Swagger UI| |false|
 |useWadlFeature|Use WADL Feature| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -51,6 +51,7 @@ sidebar_label: jaxrs-jersey
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useTags|use tags for creating interface and controller classnames| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -50,6 +50,7 @@ sidebar_label: jaxrs-resteasy-eap
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerFeature|Use dynamic Swagger generator| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -49,6 +49,7 @@ sidebar_label: jaxrs-resteasy
 |sourceFolder|source folder for generated code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -55,6 +55,7 @@ sidebar_label: jaxrs-spec
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -66,6 +66,7 @@ sidebar_label: spring
 |useOptional|Use Optional container for optional parameters| |false|
 |useTags|use tags for creating interface and controller classnames| |false|
 |virtualService|Generates the virtual service. For more details refer - https://github.com/elan-venture/virtualan/wiki| |false|
+|withAWSV4Signature|whether to include support for SigV4 signing| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -55,6 +55,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String DATE_LIBRARY = "dateLibrary";
     public static final String JAVA8_MODE = "java8";
     public static final String SUPPORT_ASYNC = "supportAsync";
+    public static final String WITH_AWSV4_SIGNATURE = "withAWSV4Signature";
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
@@ -65,6 +66,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
     protected boolean java8Mode = true;
+    protected boolean withAWSV4Signature = false;
     protected boolean withXml = false;
     protected String invokerPackage = "org.openapitools";
     protected String groupId = "org.openapitools";
@@ -196,6 +198,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(CliOption.newBoolean(FULL_JAVA_UTIL, "whether to use fully qualified name for classes under java.util. This option only works for Java API client", fullJavaUtil));
         cliOptions.add(CliOption.newBoolean(DISCRIMINATOR_CASE_SENSITIVE, "Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client", discriminatorCaseSensitive));
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, this.isHideGenerationTimestamp()));
+        cliOptions.add(CliOption.newBoolean(WITH_AWSV4_SIGNATURE, "whether to include support for SigV4 signing"));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use").defaultValue(this.getDateLibrary());
@@ -407,6 +410,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         additionalProperties.put(FULL_JAVA_UTIL, fullJavaUtil);
         additionalProperties.put("javaUtilPrefix", javaUtilPrefix);
 
+        if (additionalProperties.containsKey(WITH_AWSV4_SIGNATURE)) {
+            this.setWithAWSV4Signature(Boolean.valueOf(additionalProperties.get(WITH_AWSV4_SIGNATURE).toString()));
+        }
+        additionalProperties.put(WITH_AWSV4_SIGNATURE, withAWSV4Signature);
+
         if (additionalProperties.containsKey(WITH_XML)) {
             this.setWithXml(Boolean.valueOf(additionalProperties.get(WITH_XML).toString()));
         }
@@ -498,6 +506,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             setSupportAsync(Boolean.parseBoolean(additionalProperties.get(SUPPORT_ASYNC).toString()));
             if (supportAsync) {
                 additionalProperties.put(SUPPORT_ASYNC, "true");
+            }
+        }
+
+        if (additionalProperties.containsKey(WITH_AWSV4_SIGNATURE)) {
+            setWithAWSV4Signature(Boolean.parseBoolean(additionalProperties.get(WITH_AWSV4_SIGNATURE).toString()));
+            if (withAWSV4Signature) {
+                additionalProperties.put(WITH_AWSV4_SIGNATURE, "true");
             }
         }
 
@@ -1466,6 +1481,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public void setDiscriminatorCaseSensitive(boolean discriminatorCaseSensitive) {
         this.discriminatorCaseSensitive = discriminatorCaseSensitive;
     }
+
+    public void setWithAWSV4Signature (boolean withAWSV4Signature) { this.withAWSV4Signature = withAWSV4Signature; }
 
     public void setWithXml(boolean withXml) {
         this.withXml = withXml;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This change adds a boolean called withAWSV4Signature to the AbstractJavaCodegen.java file which is set to false by default. If the user generates an SDK with the withAWSV4Signature flag set to true in the additional properties, then this boolean is set to true. This variable is used to determine the contents of the generated SDK and whether or not to include code specific to the SigV4 process when generating.
By running ./ensure-up-to-date, documentation files were additionally updated.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
