### PR TITLE
Added detectAmznApiGatewayExtensions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -72,6 +72,9 @@ public class CodegenConstants {
     public static final String WITH_AWSV4_SIGNATURE_COMMENT = "withAWSV4Signature";
     public static final String WITH_AWSV4_SIGNATURE_COMMENT_DESC = "whether to include AWS v4 signature support";
 
+    public static final String DETECT_AMZN_APIGATEWAY_EXTENSIONS = "detectAmznApiGatewayExtensions";
+    public static final String DETECT_AMZN_APIGATEWAY_EXTENSIONS_DESC = "whether to include Api Gateway extensions, including AWSV4 support";
+
     public static final String IS_GO_SUBMODULE = "isGoSubmodule";
     public static final String IS_GO_SUBMODULE_DESC = "whether the generated Go module is a submodule";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -209,6 +209,11 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             excludeTests = Boolean.valueOf(additionalProperties.get(CodegenConstants.EXCLUDE_TESTS).toString());
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.DETECT_AMZN_APIGATEWAY_EXTENSIONS)) {
+            Boolean detectAmznApiGatewayExtensions = Boolean.valueOf(additionalProperties.get(CodegenConstants.DETECT_AMZN_APIGATEWAY_EXTENSIONS).toString());
+            additionalProperties.put(CodegenConstants.DETECT_AMZN_APIGATEWAY_EXTENSIONS, detectAmznApiGatewayExtensions);
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
         }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR adds detectAmznApiGatewayExtensions which is a flag within additional properties when generating an SDK for python. It will add support for SigV4 signing and any other future ApiGateway extensions. Added this flag to the CodegenConstants so that it can be easily referenced within the PythonClientCodegen and any future ClientCodegen files which implement detectAmznApiGatewayExtensions support.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/config/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `sigv4-python`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
